### PR TITLE
Add int8 ops for CPU and enable example for CPU

### DIFF
--- a/bitsandbytes/autograd/_functions.py
+++ b/bitsandbytes/autograd/_functions.py
@@ -224,6 +224,8 @@ matmul_cublas = MatMul8bit.apply
 
 def supports_igemmlt(device: torch.device) -> bool:
     """check if this device supports the optimized int8 kernel"""
+    if device == torch.device('cpu'):
+        return True
     if torch.cuda.get_device_capability(device=device) < (7, 5):
         return False
     device_name = torch.cuda.get_device_name(device=device)
@@ -322,13 +324,16 @@ class MatMul8bitLt(torch.autograd.Function):
             state.outlier_pool = GlobalOutlierPooler.get_instance()
 
         # Cast A to fp16
-        if A.dtype != torch.float16:
-            warnings.warn(f"MatMul8bitLt: inputs will be cast from {A.dtype} to float16 during quantization")
+        A_dtype = torch.float16
+        if A.device == torch.device('cpu'):
+            A_dtype = torch.bfloat16
+        if A.dtype != A_dtype:
+            warnings.warn(f"MatMul8bitLt: inputs will be cast from {A.dtype} to {A_dtype} during quantization")
 
         # 1. Quantize A
         if len(A.shape) == 3:
             A = A.reshape(-1, A.shape[-1])
-        CA, CAt, SCA, SCAt, coo_tensorA = F.double_quant(A.to(torch.float16), threshold=state.threshold)
+        CA, CAt, SCA, SCAt, coo_tensorA = F.double_quant(A.to(A_dtype), threshold=state.threshold)
 
         if state.threshold > 0.0 and coo_tensorA is not None:
             if state.has_fp16_weights:
@@ -403,7 +408,7 @@ class MatMul8bitLt(torch.autograd.Function):
         if using_igemmlt:
             C32A, SA = F.transform(CA, "col32")
             out32, Sout32 = F.igemmlt(C32A, state.CxB, SA, state.SB)
-            if bias is None or bias.dtype == torch.float16:
+            if bias is None or bias.dtype == torch.float16 or bias.device.type == 'cpu':
                 # we apply the fused bias here
                 output = F.mm_dequant(out32, Sout32, SCA, state.SCB, bias=bias)
                 output = output.to(A.dtype)

--- a/bitsandbytes/backends/__init__.py
+++ b/bitsandbytes/backends/__init__.py
@@ -1,4 +1,5 @@
 from .cuda import CUDABackend
+from .cpu import CPUBackend
 
 
 class Backends:
@@ -38,3 +39,4 @@ class Backends:
 
 
 Backends.register_backend("cuda", CUDABackend)
+Backends.register_backend("cpu", CPUBackend)

--- a/bitsandbytes/backends/__init__.py
+++ b/bitsandbytes/backends/__init__.py
@@ -1,5 +1,6 @@
 from .cuda import CUDABackend
 from .cpu import CPUBackend
+from .xpu import XPUBackend
 
 
 class Backends:
@@ -40,3 +41,4 @@ class Backends:
 
 Backends.register_backend("cuda", CUDABackend)
 Backends.register_backend("cpu", CPUBackend)
+Backends.register_backend("xpu", XPUBackend)

--- a/bitsandbytes/backends/cpu.py
+++ b/bitsandbytes/backends/cpu.py
@@ -1,0 +1,253 @@
+import torch
+try:
+    import intel_extension_for_pytorch
+    ipex_available = True
+except ImportError:
+    ipex_available = False
+
+Tensor = torch.Tensor
+
+def assert_on_cpu(tensors):
+    on_cpu = True
+    for t in tensors:
+        if t is None: continue # NULL pointers are fine
+        on_cpu &= (t.device.type == 'cpu')
+    if not on_cpu:
+        raise TypeError(
+            'All input tensors need to be on CPU, but found some tensors to not be on CPU:\n' \
+            f' {[(t.shape, t.device) if isinstance(t, torch.Tensor) else None for t in tensors]}'
+        )
+    return on_cpu
+
+
+class CPUBackend:
+    mm_dequant_output_dtype = torch.bfloat16
+
+    @classmethod
+    # @torch.compile(dynamic=True, options={"fx_graph_cache": True})
+    def double_quant(
+        cls, A, col_stats=None, row_stats=None, out_col=None, out_row=None, threshold=0.0
+    ):
+        """
+        Find absolute max valus of each row/column of a tensor, and symmetrically quantize it to int8.
+        If threshold > 0.0, only values <= threshold are counted. All outliers are zeroed out in
+        the original tensor and they are kept in COO format: (rows, cols, valus)
+        If threashold == 0.0, there are no outliers.
+        Args:
+            A The tensor to be analyzed and quantized.
+            col_stats Absolute max values of each column of A. If it is not None, use the values directly.
+                Otherwise, find the values.
+            row_stats Absolute max values of each row of A. If it is not None, use the values directly.
+                Otherwise, find the values.
+            out_col Output buffer for the result quantized per column if it is not None
+            out_row Output buffer for the result quantized per row if it is not None
+            threshold The threshold for finding outliers if it is > 0.0. Otherwise it has no effect.
+        Return:
+            A tuple of output quantized per row, output quantized per column, absolute max values of
+            each row of A, absolute max values of each column of A, outliers in COO format
+
+        """
+        from ..functional import COOSparseTensor
+        assert_on_cpu([A, col_stats, row_stats, out_col, out_row])
+        cols = A.shape[-1]
+        if len(A.shape) == 3:
+            rows = A.shape[0] * A.shape[1]
+        else:
+            assert A.dim() == 2, f"double_quant: Input tensor should be 2d or 3d but got {A.dim()}d"
+            rows = A.shape[0]
+        A = A.reshape(rows, cols)
+
+        coo_tensor = None
+
+        def get_row_col_stats(A):
+            row_stats = torch.max(torch.abs(A), 1).values # absolute max of each row
+            col_stats = torch.max(torch.abs(A), 0).values # absolute max of each col
+            return row_stats, col_stats
+        
+        def quant_to_int8(A, stats):
+            return torch.clamp(torch.round(A / stats * 127).to(torch.int8), -128, 127)
+
+        if threshold == 0.0:
+            if row_stats is None or col_stats is None:
+                row_stats, col_stats = get_row_col_stats(A)
+        else:
+            outlier_indices = torch.abs(A) > threshold # find outliers
+            outlier_coord = outlier_indices.nonzero() # get outlier coordinates
+            outlier_rows = outlier_coord[:, 0] # outlier row for COO sparse tensor
+            outlier_cols = outlier_coord[:, 1] # outlier column for COO sparse tensor
+            outlier_values = A[outlier_indices] # outlier values for COO sparse tensor
+            coo_tensor = COOSparseTensor(
+                A.shape[0], A.shape[1], outlier_values.numel(), outlier_rows.int(), outlier_cols.int(), outlier_values
+            )
+            if row_stats is None or col_stats is None:
+                A[outlier_indices] = 0 # zero out outliers
+                row_stats, col_stats = get_row_col_stats(A)
+                A[outlier_indices] = outlier_values # restore outliers for later use
+
+        quant_by_row = quant_to_int8(A, row_stats.unsqueeze(-1))
+        quant_by_col = quant_to_int8(A, col_stats.unsqueeze(0))
+        if out_row is not None:
+            out_row.copy_(quant_by_row)
+        else:
+            out_row = quant_by_row
+        if out_col is not None:
+            out_col.copy_(quant_by_col)
+        else:
+            out_col = quant_by_col
+        return out_row, out_col, row_stats, col_stats, coo_tensor
+
+    @classmethod
+    def transform(cls, A, to_order=None, from_order='row', out=None, transpose=False, state=None, ld=None):
+        """
+        Transform tensor A to to_order. It is originally designed for CUDA.
+        For CPU, it returns the original tensor if transpose=False.
+        Otherwise, it returns the transpose of A
+        """
+        assert_on_cpu([A, out])
+        if transpose:
+            if out is not None:
+                out.copy_(A.T)
+            else:
+                out = A.T
+        else:
+            if out is not None:
+                out.copy_(A)
+            else:
+                out = A
+        return out, state
+
+    @classmethod
+    def igemmlt(cls, A, B, SA=None, SB=None, out=None, Sout=None, dtype=torch.int32):
+        """
+        Do GEMMM computation. Data type: int8 * int8 -> int32.
+        Args:
+            A Activation of linear, data type is int8
+            B Weight of linear, data type is int8
+            SA Not used for CPU
+            SB Not used for CPU
+            out Specified output tensor if it is not None
+            Sout Not used for CPU but returned as is
+            dtype Data type of output
+        Return:
+            A tuple of GEMM result in dtype and Sout
+        """
+        assert_on_cpu([A, B])
+        assert A.dtype == torch.int8
+        assert B.dtype == torch.int8
+        if out is not None:
+            assert out.dtype == dtype
+
+        dimsA = A.ndim
+        dimsB = B.ndim
+        shapeA = A.shape
+        shapeB = B.shape
+        assert dimsA in [2, 3], 'Only two or three dimensional matrices are supported for argument A'
+        assert dimsB == 2, 'Only two dimensional matrices are supported for argument B'
+
+        if dimsA == 2:
+            m = shapeA[0]
+        elif dimsA == 3:
+            m = shapeA[0] * shapeA[1]
+        n = shapeB[0]
+        k = shapeA[-1]
+        assert shapeA[-1] == shapeB[-1], f'Shapes of A and B do not match, got {shapeA} and {shapeB}'
+        shapeOut = (shapeA[0], shapeA[1], n) if dimsA == 3 else (m, n)
+
+        # if the tensor is empty, return a transformed empty tensor with the right dimensions
+        if shapeA[0] == 0 and dimsA == 2:
+            return torch.empty((0, n), device=A.device, dtype=A.dtype)
+        elif shapeA[1] == 0 and dimsA == 3:
+            return torch.empty(tuple(shapeA[:2] + [n]), device=A.device, dtype=A.dtype)
+        
+        A_reshaped = A.reshape(m, k)
+
+        if ipex_available:
+            C = torch.ops.torch_ipex.matmul_i8i8i32(A_reshaped, B)
+        else:
+            C = torch.nn.functional.linear(A_reshaped.bfloat16(), B.bfloat16())
+        C = C.to(dtype)
+        if C.ndim != dimsA:
+            C = C.reshape(shapeOut)
+        if out is not None:
+            out.copy_(C)
+        else:
+            out = C
+
+        return out, Sout
+
+    @classmethod
+    # @torch.compile(dynamic=True, options={"fx_graph_cache": True})
+    def mm_dequant(
+        cls,
+        A,
+        quant_state,
+        row_stats,
+        col_stats,
+        out=None,
+        new_row_stats=None,
+        new_col_stats=None,
+        bias=None
+    ):
+        """
+        Dequant and add bias
+        out = A_int32 * (scale_A, scale_B) / 127 * 127 + bias
+        Args:
+            A The output of int8 gemm, whose dtype is int32
+            quant_state Not used for CPU
+            row_stats Absolute max value of each row of input (A) of gemm
+            col_stats Absolute max value of each row of weight (B) of gemm
+            out Output buffer
+            new_row_stats Not used for CPU
+            new_col_stats Not used for CPU
+            bias Bias of linear
+        Return:
+            The result
+        """
+        assert_on_cpu([A, row_stats, col_stats, out, bias])
+        assert A.dtype == torch.int32
+        compute_dtype = torch.bfloat16
+        output_dtype = cls.mm_dequant_output_dtype
+        out_shape = A.shape
+        if len(out_shape) == 3:
+            out_shape = (out_shape[0] * out_shape[1], out_shape[2])
+
+        A_reshaped = A.reshape(out_shape).to(compute_dtype)
+        row_stats = row_stats.reshape(-1).unsqueeze(-1).to(compute_dtype)
+        col_stats = col_stats.reshape(-1).unsqueeze(0).to(compute_dtype)
+        out = A_reshaped * row_stats * col_stats / (127 * 127)
+        if bias is not None:
+            out = out + bias.to(compute_dtype)
+        out = out.to(output_dtype)
+        return out
+
+    @classmethod
+    def extract_outliers(cls, A, SA, idx):
+        """
+        Extract columns of A by idx
+        """
+        assert_on_cpu([A])
+        return A[:, idx].contiguous()
+
+    @classmethod
+    def quantize_4bit(
+        cls,
+        A: Tensor,
+        absmax: Tensor = None,
+        out: Tensor = None,
+        blocksize=64,
+        compress_statistics=False,
+        quant_type="fp4",
+    ) -> Tensor:
+        assert False, "quantize_4bit not yet implemented for CPU backend"
+
+    @classmethod
+    def dequantize_4bit(
+        cls,
+        A: Tensor,
+        quant_state = None,
+        absmax: Tensor = None,
+        out: Tensor = None,
+        blocksize: int = 64,
+        quant_type="fp4",
+    ) -> Tensor:
+        assert False, "dequantize_4bit not yet implemented for CPU backend"

--- a/bitsandbytes/backends/cpu.py
+++ b/bitsandbytes/backends/cpu.py
@@ -20,81 +20,194 @@ def assert_on_cpu(tensors):
     return on_cpu
 
 
+@torch.compile(dynamic=True, options={"fx_graph_cache": True})
+def double_quant_common(
+    A, col_stats=None, row_stats=None, out_col=None, out_row=None, threshold=0.0
+):
+    """
+    Find absolute max valus of each row/column of a tensor, and symmetrically quantize it to int8.
+    If threshold > 0.0, only values <= threshold are counted. All outliers are zeroed out in
+    the original tensor and they are kept in COO format: (rows, cols, valus)
+    If threashold == 0.0, there are no outliers.
+    Args:
+        A The tensor to be analyzed and quantized.
+        col_stats Absolute max values of each column of A. If it is not None, use the values directly.
+            Otherwise, find the values.
+        row_stats Absolute max values of each row of A. If it is not None, use the values directly.
+            Otherwise, find the values.
+        out_col Output buffer for the result quantized per column if it is not None
+        out_row Output buffer for the result quantized per row if it is not None
+        threshold The threshold for finding outliers if it is > 0.0. Otherwise it has no effect.
+    Return:
+        A tuple of output quantized per row, output quantized per column, absolute max values of
+        each row of A, absolute max values of each column of A, outliers in COO format
+
+    """
+    from ..functional import COOSparseTensor
+    cols = A.shape[-1]
+    if len(A.shape) == 3:
+        rows = A.shape[0] * A.shape[1]
+    else:
+        assert A.dim() == 2, f"double_quant: Input tensor should be 2d or 3d but got {A.dim()}d"
+        rows = A.shape[0]
+    A = A.reshape(rows, cols)
+
+    coo_tensor = None
+
+    def get_row_col_stats(A):
+        row_stats = torch.max(torch.abs(A), 1).values # absolute max of each row
+        col_stats = torch.max(torch.abs(A), 0).values # absolute max of each col
+        return row_stats, col_stats
+    
+    def quant_to_int8(A, stats):
+        return torch.clamp(torch.round(A / stats * 127).to(torch.int8), -128, 127)
+
+    if threshold == 0.0:
+        if row_stats is None or col_stats is None:
+            row_stats, col_stats = get_row_col_stats(A)
+    else:
+        outlier_indices = torch.abs(A) > threshold # find outliers
+        outlier_coord = outlier_indices.nonzero() # get outlier coordinates
+        outlier_rows = outlier_coord[:, 0] # outlier row for COO sparse tensor
+        outlier_cols = outlier_coord[:, 1] # outlier column for COO sparse tensor
+        outlier_values = A[outlier_indices] # outlier values for COO sparse tensor
+        coo_tensor = COOSparseTensor(
+            A.shape[0], A.shape[1], outlier_values.numel(), outlier_rows.int(), outlier_cols.int(), outlier_values
+        )
+        if row_stats is None or col_stats is None:
+            A[outlier_indices] = 0 # zero out outliers
+            row_stats, col_stats = get_row_col_stats(A)
+            A[outlier_indices] = outlier_values # restore outliers for later use
+
+    quant_by_row = quant_to_int8(A, row_stats.unsqueeze(-1))
+    quant_by_col = quant_to_int8(A, col_stats.unsqueeze(0))
+    if out_row is not None:
+        out_row.copy_(quant_by_row)
+    else:
+        out_row = quant_by_row
+    if out_col is not None:
+        out_col.copy_(quant_by_col)
+    else:
+        out_col = quant_by_col
+    return out_row, out_col, row_stats, col_stats, coo_tensor
+
+
+def igemmlt_common(
+    A, B, SA=None, SB=None, out=None, Sout=None, dtype=torch.int32
+):
+    """
+    Do GEMMM computation. Data type: int8 * int8 -> int32.
+    Args:
+        A Activation of linear, data type is int8
+        B Weight of linear, data type is int8
+        SA Not used for CPU/XPU
+        SB Not used for CPU/XPU
+        out Specified output tensor if it is not None
+        Sout Not used for CPU/XPU but returned as is
+        dtype Data type of output
+    Return:
+        A tuple of GEMM result in dtype and Sout
+    """
+    assert A.dtype == torch.int8
+    assert B.dtype == torch.int8
+    if out is not None:
+        assert out.dtype == dtype
+
+    dimsA = A.ndim
+    dimsB = B.ndim
+    shapeA = A.shape
+    shapeB = B.shape
+    assert dimsA in [2, 3], 'Only two or three dimensional matrices are supported for argument A'
+    assert dimsB == 2, 'Only two dimensional matrices are supported for argument B'
+
+    if dimsA == 2:
+        m = shapeA[0]
+    elif dimsA == 3:
+        m = shapeA[0] * shapeA[1]
+    n = shapeB[0]
+    k = shapeA[-1]
+    assert shapeA[-1] == shapeB[-1], f'Shapes of A and B do not match, got {shapeA} and {shapeB}'
+    shapeOut = (shapeA[0], shapeA[1], n) if dimsA == 3 else (m, n)
+
+    # if the tensor is empty, return a transformed empty tensor with the right dimensions
+    if shapeA[0] == 0 and dimsA == 2:
+        return torch.empty((0, n), device=A.device, dtype=A.dtype)
+    elif shapeA[1] == 0 and dimsA == 3:
+        return torch.empty(tuple(shapeA[:2] + [n]), device=A.device, dtype=A.dtype)
+    
+    A_reshaped = A.reshape(m, k)
+
+    if ipex_available:
+        C = torch.ops.torch_ipex.matmul_i8i8i32(A_reshaped, B)
+    else:
+        C = torch.nn.functional.linear(A_reshaped.float(), B.float())
+    C = C.to(dtype)
+    if C.ndim != dimsA:
+        C = C.reshape(shapeOut)
+    if out is not None:
+        out.copy_(C)
+    else:
+        out = C
+
+    return out, Sout
+
+
+@torch.compile(dynamic=True, options={"fx_graph_cache": True})
+def mm_dequant_common(
+    A,
+    quant_state,
+    row_stats,
+    col_stats,
+    out=None,
+    new_row_stats=None,
+    new_col_stats=None,
+    bias=None,
+    compute_dtype=torch.float32,
+    output_dtype=torch.float32
+):
+    """
+    Dequant and add bias
+    out = A_int32 * (scale_A, scale_B) / 127 * 127 + bias
+    Args:
+        A The output of int8 gemm, whose dtype is int32
+        quant_state Not used for CPU
+        row_stats Absolute max value of each row of input (A) of gemm
+        col_stats Absolute max value of each row of weight (B) of gemm
+        out Output buffer
+        new_row_stats Not used for CPU/XPU
+        new_col_stats Not used for CPU/XPU
+        bias Bias of linear
+        compute_dtype Data type for computation
+        output_dtype Data type for output
+    Return:
+        The result
+    """
+    assert A.dtype == torch.int32
+    out_shape = A.shape
+    if len(out_shape) == 3:
+        out_shape = (out_shape[0] * out_shape[1], out_shape[2])
+
+    A_reshaped = A.reshape(out_shape).to(compute_dtype)
+    row_stats = row_stats.reshape(-1).unsqueeze(-1).to(compute_dtype)
+    col_stats = col_stats.reshape(-1).unsqueeze(0).to(compute_dtype)
+    out = A_reshaped * row_stats * col_stats / (127 * 127)
+    if bias is not None:
+        out = out + bias.to(compute_dtype)
+    out = out.to(output_dtype)
+    return out
+
+
+
 class CPUBackend:
+    mm_dequant_compute_dtype = torch.bfloat16
     mm_dequant_output_dtype = torch.bfloat16
 
     @classmethod
-    # @torch.compile(dynamic=True, options={"fx_graph_cache": True})
     def double_quant(
         cls, A, col_stats=None, row_stats=None, out_col=None, out_row=None, threshold=0.0
     ):
-        """
-        Find absolute max valus of each row/column of a tensor, and symmetrically quantize it to int8.
-        If threshold > 0.0, only values <= threshold are counted. All outliers are zeroed out in
-        the original tensor and they are kept in COO format: (rows, cols, valus)
-        If threashold == 0.0, there are no outliers.
-        Args:
-            A The tensor to be analyzed and quantized.
-            col_stats Absolute max values of each column of A. If it is not None, use the values directly.
-                Otherwise, find the values.
-            row_stats Absolute max values of each row of A. If it is not None, use the values directly.
-                Otherwise, find the values.
-            out_col Output buffer for the result quantized per column if it is not None
-            out_row Output buffer for the result quantized per row if it is not None
-            threshold The threshold for finding outliers if it is > 0.0. Otherwise it has no effect.
-        Return:
-            A tuple of output quantized per row, output quantized per column, absolute max values of
-            each row of A, absolute max values of each column of A, outliers in COO format
-
-        """
-        from ..functional import COOSparseTensor
         assert_on_cpu([A, col_stats, row_stats, out_col, out_row])
-        cols = A.shape[-1]
-        if len(A.shape) == 3:
-            rows = A.shape[0] * A.shape[1]
-        else:
-            assert A.dim() == 2, f"double_quant: Input tensor should be 2d or 3d but got {A.dim()}d"
-            rows = A.shape[0]
-        A = A.reshape(rows, cols)
-
-        coo_tensor = None
-
-        def get_row_col_stats(A):
-            row_stats = torch.max(torch.abs(A), 1).values # absolute max of each row
-            col_stats = torch.max(torch.abs(A), 0).values # absolute max of each col
-            return row_stats, col_stats
-        
-        def quant_to_int8(A, stats):
-            return torch.clamp(torch.round(A / stats * 127).to(torch.int8), -128, 127)
-
-        if threshold == 0.0:
-            if row_stats is None or col_stats is None:
-                row_stats, col_stats = get_row_col_stats(A)
-        else:
-            outlier_indices = torch.abs(A) > threshold # find outliers
-            outlier_coord = outlier_indices.nonzero() # get outlier coordinates
-            outlier_rows = outlier_coord[:, 0] # outlier row for COO sparse tensor
-            outlier_cols = outlier_coord[:, 1] # outlier column for COO sparse tensor
-            outlier_values = A[outlier_indices] # outlier values for COO sparse tensor
-            coo_tensor = COOSparseTensor(
-                A.shape[0], A.shape[1], outlier_values.numel(), outlier_rows.int(), outlier_cols.int(), outlier_values
-            )
-            if row_stats is None or col_stats is None:
-                A[outlier_indices] = 0 # zero out outliers
-                row_stats, col_stats = get_row_col_stats(A)
-                A[outlier_indices] = outlier_values # restore outliers for later use
-
-        quant_by_row = quant_to_int8(A, row_stats.unsqueeze(-1))
-        quant_by_col = quant_to_int8(A, col_stats.unsqueeze(0))
-        if out_row is not None:
-            out_row.copy_(quant_by_row)
-        else:
-            out_row = quant_by_row
-        if out_col is not None:
-            out_col.copy_(quant_by_col)
-        else:
-            out_col = quant_by_col
-        return out_row, out_col, row_stats, col_stats, coo_tensor
+        return double_quant_common(A, col_stats, row_stats, out_col, out_row)
 
     @classmethod
     def transform(cls, A, to_order=None, from_order='row', out=None, transpose=False, state=None, ld=None):
@@ -118,65 +231,10 @@ class CPUBackend:
 
     @classmethod
     def igemmlt(cls, A, B, SA=None, SB=None, out=None, Sout=None, dtype=torch.int32):
-        """
-        Do GEMMM computation. Data type: int8 * int8 -> int32.
-        Args:
-            A Activation of linear, data type is int8
-            B Weight of linear, data type is int8
-            SA Not used for CPU
-            SB Not used for CPU
-            out Specified output tensor if it is not None
-            Sout Not used for CPU but returned as is
-            dtype Data type of output
-        Return:
-            A tuple of GEMM result in dtype and Sout
-        """
         assert_on_cpu([A, B])
-        assert A.dtype == torch.int8
-        assert B.dtype == torch.int8
-        if out is not None:
-            assert out.dtype == dtype
-
-        dimsA = A.ndim
-        dimsB = B.ndim
-        shapeA = A.shape
-        shapeB = B.shape
-        assert dimsA in [2, 3], 'Only two or three dimensional matrices are supported for argument A'
-        assert dimsB == 2, 'Only two dimensional matrices are supported for argument B'
-
-        if dimsA == 2:
-            m = shapeA[0]
-        elif dimsA == 3:
-            m = shapeA[0] * shapeA[1]
-        n = shapeB[0]
-        k = shapeA[-1]
-        assert shapeA[-1] == shapeB[-1], f'Shapes of A and B do not match, got {shapeA} and {shapeB}'
-        shapeOut = (shapeA[0], shapeA[1], n) if dimsA == 3 else (m, n)
-
-        # if the tensor is empty, return a transformed empty tensor with the right dimensions
-        if shapeA[0] == 0 and dimsA == 2:
-            return torch.empty((0, n), device=A.device, dtype=A.dtype)
-        elif shapeA[1] == 0 and dimsA == 3:
-            return torch.empty(tuple(shapeA[:2] + [n]), device=A.device, dtype=A.dtype)
-        
-        A_reshaped = A.reshape(m, k)
-
-        if ipex_available:
-            C = torch.ops.torch_ipex.matmul_i8i8i32(A_reshaped, B)
-        else:
-            C = torch.nn.functional.linear(A_reshaped.bfloat16(), B.bfloat16())
-        C = C.to(dtype)
-        if C.ndim != dimsA:
-            C = C.reshape(shapeOut)
-        if out is not None:
-            out.copy_(C)
-        else:
-            out = C
-
-        return out, Sout
+        return igemmlt_common(A, B, SA, SB, out, Sout, dtype)
 
     @classmethod
-    # @torch.compile(dynamic=True, options={"fx_graph_cache": True})
     def mm_dequant(
         cls,
         A,
@@ -188,37 +246,19 @@ class CPUBackend:
         new_col_stats=None,
         bias=None
     ):
-        """
-        Dequant and add bias
-        out = A_int32 * (scale_A, scale_B) / 127 * 127 + bias
-        Args:
-            A The output of int8 gemm, whose dtype is int32
-            quant_state Not used for CPU
-            row_stats Absolute max value of each row of input (A) of gemm
-            col_stats Absolute max value of each row of weight (B) of gemm
-            out Output buffer
-            new_row_stats Not used for CPU
-            new_col_stats Not used for CPU
-            bias Bias of linear
-        Return:
-            The result
-        """
         assert_on_cpu([A, row_stats, col_stats, out, bias])
-        assert A.dtype == torch.int32
-        compute_dtype = torch.bfloat16
-        output_dtype = cls.mm_dequant_output_dtype
-        out_shape = A.shape
-        if len(out_shape) == 3:
-            out_shape = (out_shape[0] * out_shape[1], out_shape[2])
-
-        A_reshaped = A.reshape(out_shape).to(compute_dtype)
-        row_stats = row_stats.reshape(-1).unsqueeze(-1).to(compute_dtype)
-        col_stats = col_stats.reshape(-1).unsqueeze(0).to(compute_dtype)
-        out = A_reshaped * row_stats * col_stats / (127 * 127)
-        if bias is not None:
-            out = out + bias.to(compute_dtype)
-        out = out.to(output_dtype)
-        return out
+        return mm_dequant_common(
+            A,
+            quant_state,
+            row_stats,
+            col_stats,
+            out,
+            new_row_stats,
+            new_col_stats,
+            bias,
+            cls.mm_dequant_compute_dtype,
+            cls.mm_dequant_output_dtype
+        )
 
     @classmethod
     def extract_outliers(cls, A, SA, idx):

--- a/bitsandbytes/backends/xpu.py
+++ b/bitsandbytes/backends/xpu.py
@@ -1,0 +1,123 @@
+# For Intel GPU (xpu is the device name for Intel GPU in PyTorch)
+import torch
+try:
+    import intel_extension_for_pytorch
+    ipex_available = True
+except ImportError:
+    ipex_available = False
+from .cpu import (
+    double_quant_common,
+    igemmlt_common,
+    mm_dequant_common,
+)
+
+Tensor = torch.Tensor
+
+def assert_on_xpu(tensors):
+    on_xpu = True
+    for t in tensors:
+        if t is None: continue # NULL pointers are fine
+        on_xpu &= (t.device.type == 'xpu')
+    if not on_xpu:
+        raise TypeError(
+            'All input tensors need to be on XPU, but found some tensors to not be on XPU:\n' \
+            f' {[(t.shape, t.device) if isinstance(t, torch.Tensor) else None for t in tensors]}'
+        )
+    return on_xpu
+
+
+class XPUBackend:
+    mm_dequant_compute_dtype = torch.half
+    mm_dequant_output_dtype = torch.half
+
+    @classmethod
+    @torch.compile(dynamic=True, options={"fx_graph_cache": True})
+    def double_quant(
+        cls, A, col_stats=None, row_stats=None, out_col=None, out_row=None, threshold=0.0
+    ):
+        assert_on_xpu([A, col_stats, row_stats, out_col, out_row])
+        return double_quant_common(A, col_stats, row_stats, out_col, out_row)
+
+    @classmethod
+    def transform(cls, A, to_order=None, from_order='row', out=None, transpose=False, state=None, ld=None):
+        """
+        Transform tensor A to to_order. It is originally designed for CUDA.
+        For XPU, it returns the original tensor if transpose=False.
+        Otherwise, it returns the transpose of A
+        """
+        assert_on_xpu([A, out])
+        if transpose:
+            if out is not None:
+                out.copy_(A.T)
+            else:
+                out = A.T
+        else:
+            if out is not None:
+                out.copy_(A)
+            else:
+                out = A
+        return out, state
+
+    @classmethod
+    def igemmlt(cls, A, B, SA=None, SB=None, out=None, Sout=None, dtype=torch.int32):
+        assert_on_xpu([A, B])
+        return igemmlt_common(A, B, SA, SB, out, Sout, dtype)
+
+    @classmethod
+    @torch.compile(dynamic=True, options={"fx_graph_cache": True})
+    def mm_dequant(
+        cls,
+        A,
+        quant_state,
+        row_stats,
+        col_stats,
+        out=None,
+        new_row_stats=None,
+        new_col_stats=None,
+        bias=None
+    ):
+        assert_on_xpu([A, row_stats, col_stats, out, bias])
+        return mm_dequant_common(
+            A,
+            quant_state,
+            row_stats,
+            col_stats,
+            out,
+            new_row_stats,
+            new_col_stats,
+            bias,
+            cls.mm_dequant_compute_dtype,
+            cls.mm_dequant_output_dtype
+        )
+
+    @classmethod
+    def extract_outliers(cls, A, SA, idx):
+        """
+        Extract columns of A by idx
+        """
+        assert_on_xpu([A])
+        return A[:, idx].contiguous()
+
+    @classmethod
+    def quantize_4bit(
+        cls,
+        A: Tensor,
+        absmax: Tensor = None,
+        out: Tensor = None,
+        blocksize=64,
+        compress_statistics=False,
+        quant_type="fp4",
+    ) -> Tensor:
+        assert False, "quantize_4bit not yet implemented for XPU backend"
+
+    @classmethod
+    def dequantize_4bit(
+        cls,
+        A: Tensor,
+        quant_state = None,
+        absmax: Tensor = None,
+        out: Tensor = None,
+        blocksize: int = 64,
+        quant_type="fp4",
+    ) -> Tensor:
+        assert False, "dequantize_4bit not yet implemented for XPU backend"

--- a/bitsandbytes/device_setup/cpu/main.py
+++ b/bitsandbytes/device_setup/cpu/main.py
@@ -1,0 +1,40 @@
+from packaging import version
+import importlib.metadata
+from warnings import warn
+def _is_package_available(pkg_name: str, return_version: bool = False) -> Union[Tuple[bool, str], bool]:
+    # Check we're not importing a "pkg_name" directory somewhere but the actual library by trying to grab the version
+    package_exists = importlib.util.find_spec(pkg_name) is not None
+    package_version = "N/A"
+    if package_exists:
+        try:
+            package_version = importlib.metadata.version(pkg_name)
+            package_exists = True
+        except importlib.metadata.PackageNotFoundError:
+            package_exists = False
+    if return_version:
+        return package_exists, package_version
+    else:
+        return package_exists
+
+_torch_version = "N/A"
+_torch_available = False
+_torch_available, _torch_version = _is_package_available("torch", return_version=True)
+_ipex_available, _ipex_version = _is_package_available("intel_extension_for_pytorch", return_version=True)
+
+def is_ipex_cpu_available():
+    def get_major_and_minor_from_version(full_version):
+        return str(version.parse(full_version).major) + "." + str(version.parse(full_version).minor)
+
+    if not _torch_available or not _ipex_available:
+        return False
+
+    torch_major_and_minor = get_major_and_minor_from_version(_torch_version)
+    ipex_major_and_minor = get_major_and_minor_from_version(_ipex_version)
+    if torch_major_and_minor != ipex_major_and_minor:
+        warn(
+            f"Intel Extension for PyTorch {ipex_major_and_minor} needs to work with PyTorch {ipex_major_and_minor}.*,"
+            f" but PyTorch {_torch_version} is found. Please switch to the matching version and run again."
+            "Refer to https://intel.github.io/intel-extension-for-pytorch/ for more details."
+        )
+        return False
+    return True

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -1694,7 +1694,10 @@ class COOSparseTensor:
     def __init__(self, rows, cols, nnz, rowidx, colidx, values):
         assert rowidx.dtype == torch.int32
         assert colidx.dtype == torch.int32
-        assert values.dtype == torch.float16
+        if values.device == torch.device('cpu'):
+            assert values.dtype in [torch.bfloat16, torch.float]
+        else:
+            assert values.dtype == torch.float16
         assert values.numel() == nnz
         assert rowidx.numel() == nnz
         assert colidx.numel() == nnz

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -314,6 +314,19 @@ class Int8Params(torch.nn.Parameter):
 
         return self
 
+    def cpu(self):
+        # we store the 8-bit rows-major weight
+        B = self.data.contiguous().bfloat16().cpu()
+        CB, CBt, SCB, SCBt, coo_tensorB = bnb.functional.double_quant(B)
+        if CBt is not None:
+            del CBt
+        if SCBt is not None:
+            del SCBt
+        self.data = CB
+        setattr(self, "CB", CB)
+        setattr(self, "SCB", SCB)
+        return self
+
     @overload
     def to(
         self: T,
@@ -342,6 +355,12 @@ class Int8Params(torch.nn.Parameter):
             and self.data.device.type == "cpu"
         ):
             return self.cuda(device)
+        elif (
+            device is not None
+            and device.type == "cpu"
+            and self.data.dtype != torch.int8
+        ):
+            return self.cpu()
         else:
             new_param = Int8Params(
                 super().to(

--- a/examples/int8_inference_huggingface_cpu.py
+++ b/examples/int8_inference_huggingface_cpu.py
@@ -1,0 +1,21 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MAX_NEW_TOKENS = 128
+model_name = "./opt-1.3b"
+
+text = 'Hamburg is in which country?\n'
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+input_ids = tokenizer(text, return_tensors="pt").input_ids
+
+model = AutoModelForCausalLM.from_pretrained(
+  model_name,
+  device_map='auto',
+  load_in_8bit=True,
+  torch_dtype=torch.bfloat16
+)
+print('[info] model dtype', model.dtype)
+with torch.no_grad():
+  generated_ids = model.generate(input_ids, max_length=MAX_NEW_TOKENS)
+output = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
+print("output:", output, " (type =", type(output), ", len =", len(output), ")")

--- a/examples/int8_inference_huggingface_cpu.py
+++ b/examples/int8_inference_huggingface_cpu.py
@@ -1,13 +1,15 @@
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
+import time
 
-MAX_NEW_TOKENS = 128
+MAX_NEW_TOKENS = 64
 model_name = "./opt-1.3b"
 
 text = 'Hamburg is in which country?\n'
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 input_ids = tokenizer(text, return_tensors="pt").input_ids
 
+print('[info] Loading model...')
 model = AutoModelForCausalLM.from_pretrained(
   model_name,
   device_map='auto',
@@ -15,7 +17,29 @@ model = AutoModelForCausalLM.from_pretrained(
   torch_dtype=torch.bfloat16
 )
 print('[info] model dtype', model.dtype)
+
 with torch.no_grad():
-  generated_ids = model.generate(input_ids, max_length=MAX_NEW_TOKENS)
+    t0 = time.time()
+    generated_ids = model.generate(input_ids, max_length=MAX_NEW_TOKENS)
+    latency = time.time() - t0
+    result = "| latency: " + str(round(latency * 1000, 3)) + " ms |"
+    print('+' + '-' * (len(result) - 2) + '+')
+    print(result)
+    print('+' + '-' * (len(result) - 2) + '+')
+
+def trace_handler(prof):
+    print(prof.key_averages().table(
+        sort_by="cpu_time_total", row_limit=-1))
+    # prof.export_chrome_trace("bnb_int8_cpu.json")
+
+with torch.no_grad(), torch.profiler.profile(
+    activities=[torch.profiler.ProfilerActivity.CPU],
+    schedule=torch.profiler.schedule(
+        wait=0, warmup=3, active=1, repeat=0),
+    on_trace_ready=trace_handler
+    ) as p:
+        for i in range(4):
+            generated_ids = model.generate(input_ids, max_length=MAX_NEW_TOKENS)
+            p.step()
 output = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
 print("output:", output, " (type =", type(output), ", len =", len(output), ")")


### PR DESCRIPTION
As the title.
Need a patch for transformers to run the example for CPU.

Example:
```
python examples/int8_inference_huggingface_cpu.py
```
Need to apply the patch for transformers to run.
```diff
diff --git a/src/transformers/modeling_utils.py b/src/transformers/modeling_utils.py
index 2588893d2..ec2d2db20 100644
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2860,8 +2860,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )
 
         if load_in_8bit or load_in_4bit:
-            if not torch.cuda.is_available():
-                raise RuntimeError("No GPU found. A GPU is needed for quantization.")
+            # if not torch.cuda.is_available():
+            #     raise RuntimeError("No GPU found. A GPU is needed for quantization.")
             if not (is_accelerate_available() and is_bitsandbytes_available()):
                 raise ImportError(
                     "Using `load_in_8bit=True` requires Accelerate: `pip install accelerate` and the latest version of"
@@ -3054,8 +3054,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if device_map is None:
                     if torch.cuda.is_available():
                         device_map = {"": torch.cuda.current_device()}
-                    else:
-                        raise RuntimeError("No GPU found. A GPU is needed for quantization.")
+                    # else:
+                    #     raise RuntimeError("No GPU found. A GPU is needed for quantization.")
                     logger.info(
                         "The device_map was not initialized. "
                         "Setting device_map to {'':torch.cuda.current_device()}. "
@@ -3596,17 +3596,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 device_map_without_lm_head = {
                     key: device_map[key] for key in device_map.keys() if key not in modules_to_not_convert
                 }
-                if "cpu" in device_map_without_lm_head.values() or "disk" in device_map_without_lm_head.values():
-                    raise ValueError(
-                        """
-                        Some modules are dispatched on the CPU or the disk. Make sure you have enough GPU RAM to fit
-                        the quantized model. If you want to dispatch the model on the CPU or the disk while keeping
-                        these modules in 32-bit, you need to set `load_in_8bit_fp32_cpu_offload=True` and pass a custom
-                        `device_map` to `from_pretrained`. Check
-                        https://huggingface.co/docs/transformers/main/en/main_classes/quantization#offload-between-cpu-and-gpu
-                        for more details.
-                        """
-                    )
+                # if "cpu" in device_map_without_lm_head.values() or "disk" in device_map_without_lm_head.values():
+                #     raise ValueError(
+                #         """
+                #         Some modules are dispatched on the CPU or the disk. Make sure you have enough GPU RAM to fit
+                #         the quantized model. If you want to dispatch the model on the CPU or the disk while keeping
+                #         these modules in 32-bit, you need to set `load_in_8bit_fp32_cpu_offload=True` and pass a custom
+                #         `device_map` to `from_pretrained`. Check
+                #         https://huggingface.co/docs/transformers/main/en/main_classes/quantization#offload-between-cpu-and-gpu
+                #         for more details.
+                #         """
+                #     )
                 del device_map_without_lm_head
 
         elif device_map is not None:
diff --git a/src/transformers/utils/import_utils.py b/src/transformers/utils/import_utils.py
index bf7530e84..b485536a9 100644
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -611,7 +611,7 @@ def is_bitsandbytes_available():
     # let's avoid that by adding a simple check
     import torch
 
-    return _bitsandbytes_available and torch.cuda.is_available()
+    return _bitsandbytes_available  # and torch.cuda.is_available()
 
 
 def is_flash_attn_2_available():
```
