### PR TITLE
Add nf4 cpu/xpu ops and an example

### DIFF
--- a/bitsandbytes/backends/cpu.py
+++ b/bitsandbytes/backends/cpu.py
@@ -3,6 +3,8 @@ from .common_ops import (
     double_quant_common,
     igemmlt_common,
     mm_dequant_common,
+    quantize_4bit_common,
+    dequantize_4bit_common,
 )
 
 Tensor = torch.Tensor
@@ -100,7 +102,8 @@ class CPUBackend:
         compress_statistics=False,
         quant_type="fp4",
     ) -> Tensor:
-        assert False, "quantize_4bit not yet implemented for CPU backend"
+        assert_on_cpu([A, absmax, out])
+        return quantize_4bit_common(A, absmax, out, blocksize, compress_statistics, quant_type)
 
     @classmethod
     def dequantize_4bit(
@@ -112,4 +115,5 @@ class CPUBackend:
         blocksize: int = 64,
         quant_type="fp4",
     ) -> Tensor:
-        assert False, "dequantize_4bit not yet implemented for CPU backend"
+        assert_on_cpu([A, absmax, out])
+        return dequantize_4bit_common(A, quant_state, absmax, out, blocksize, quant_type)

--- a/bitsandbytes/backends/xpu.py
+++ b/bitsandbytes/backends/xpu.py
@@ -103,7 +103,8 @@ class XPUBackend:
         compress_statistics=False,
         quant_type="fp4",
     ) -> Tensor:
-        assert False, "quantize_4bit not yet implemented for XPU backend"
+        assert_on_xpu([A, absmax, out])
+        return quantize_4bit_common(A, absmax, out, blocksize, compress_statistics, quant_type)
 
     @classmethod
     def dequantize_4bit(
@@ -115,4 +116,5 @@ class XPUBackend:
         blocksize: int = 64,
         quant_type="fp4",
     ) -> Tensor:
-        assert False, "dequantize_4bit not yet implemented for XPU backend"
+        assert_on_xpu([A, absmax, out])
+        return dequantize_4bit_common(A, quant_state, absmax, out, blocksize, quant_type)

--- a/examples/nf4_inference_huggingface_cpu.py
+++ b/examples/nf4_inference_huggingface_cpu.py
@@ -1,0 +1,57 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+import time
+
+MAX_NEW_TOKENS = 64
+model_name = "./opt-1.3b"
+# model_name = "./gpt-j-6b"
+
+text = 'Hamburg is in which country?\n'
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+input_ids = tokenizer(text, return_tensors="pt").input_ids
+
+print('[info] Loading model...')
+t0 = time.time()
+nf4_config = BitsAndBytesConfig(
+   load_in_4bit=True,
+   bnb_4bit_quant_type="nf4",
+   bnb_4bit_use_double_quant=False,
+   bnb_4bit_compute_dtype=torch.bfloat16
+)
+model = AutoModelForCausalLM.from_pretrained(
+  model_name,
+  device_map='auto',
+  torch_dtype=torch.bfloat16,
+  quantization_config=nf4_config,
+)
+print('[info] model loaded, time elapsed', round(time.time() - t0, 3), "sec")
+print('[info] model dtype', model.dtype)
+
+with torch.no_grad():
+    t0 = time.time()
+    generated_ids = model.generate(input_ids, max_length=MAX_NEW_TOKENS)
+    latency = time.time() - t0
+    result = "| latency: " + str(round(latency * 1000, 3)) + " ms |"
+    print('+' + '-' * (len(result) - 2) + '+')
+    print(result)
+    print('+' + '-' * (len(result) - 2) + '+')
+    output = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
+    print("output:", output, " (type =", type(output), ", len =", len(output), ")")
+    quit()
+
+def trace_handler(prof):
+    print(prof.key_averages().table(
+        sort_by="cpu_time_total", row_limit=-1))
+    # prof.export_chrome_trace("bnb_int8_cpu.json")
+
+with torch.no_grad(), torch.profiler.profile(
+    activities=[torch.profiler.ProfilerActivity.CPU],
+    schedule=torch.profiler.schedule(
+        wait=0, warmup=3, active=1, repeat=0),
+    on_trace_ready=trace_handler
+    ) as p:
+        for i in range(4):
+            generated_ids = model.generate(input_ids, max_length=MAX_NEW_TOKENS)
+            p.step()
+output = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
+print("output:", output, " (type =", type(output), ", len =", len(output), ")")


### PR DESCRIPTION
As the title.
Run the example:
```
python examples/nf4_inference_huggingface_cpu.py
```
Need the following patch for transformers to run:
```diff
diff --git a/src/transformers/modeling_utils.py b/src/transformers/modeling_utils.py
index 2588893d2..ec2d2db20 100644
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2860,8 +2860,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )

         if load_in_8bit or load_in_4bit:
-            if not torch.cuda.is_available():
-                raise RuntimeError("No GPU found. A GPU is needed for quantization.")
+            # if not torch.cuda.is_available():
+            #     raise RuntimeError("No GPU found. A GPU is needed for quantization.")
             if not (is_accelerate_available() and is_bitsandbytes_available()):
                 raise ImportError(
                     "Using `load_in_8bit=True` requires Accelerate: `pip install accelerate` and the latest version of"
@@ -3054,8 +3054,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if device_map is None:
                     if torch.cuda.is_available():
                         device_map = {"": torch.cuda.current_device()}
-                    else:
-                        raise RuntimeError("No GPU found. A GPU is needed for quantization.")
+                    # else:
+                    #     raise RuntimeError("No GPU found. A GPU is needed for quantization.")
                     logger.info(
                         "The device_map was not initialized. "
                         "Setting device_map to {'':torch.cuda.current_device()}. "
@@ -3596,17 +3596,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 device_map_without_lm_head = {
                     key: device_map[key] for key in device_map.keys() if key not in modules_to_not_convert
                 }
-                if "cpu" in device_map_without_lm_head.values() or "disk" in device_map_without_lm_head.values():
-                    raise ValueError(
-                        """
-                        Some modules are dispatched on the CPU or the disk. Make sure you have enough GPU RAM to fit
-                        the quantized model. If you want to dispatch the model on the CPU or the disk while keeping
-                        these modules in 32-bit, you need to set `load_in_8bit_fp32_cpu_offload=True` and pass a custom
-                        `device_map` to `from_pretrained`. Check
-                        https://huggingface.co/docs/transformers/main/en/main_classes/quantization#offload-between-cpu-and-gpu
-                        for more details.
-                        """
-                    )
+                # if "cpu" in device_map_without_lm_head.values() or "disk" in device_map_without_lm_head.values():
+                #     raise ValueError(
+                #         """
+                #         Some modules are dispatched on the CPU or the disk. Make sure you have enough GPU RAM to fit
+                #         the quantized model. If you want to dispatch the model on the CPU or the disk while keeping
+                #         these modules in 32-bit, you need to set `load_in_8bit_fp32_cpu_offload=True` and pass a custom
+                #         `device_map` to `from_pretrained`. Check
+                #         https://huggingface.co/docs/transformers/main/en/main_classes/quantization#offload-between-cpu-and-gpu
+                #         for more details.
+                #         """
+                #     )
                 del device_map_without_lm_head

         elif device_map is not None:
diff --git a/src/transformers/utils/import_utils.py b/src/transformers/utils/import_utils.py
index bf7530e84..b485536a9 100644
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -611,7 +611,7 @@ def is_bitsandbytes_available():
     # let's avoid that by adding a simple check
     import torch

-    return _bitsandbytes_available and torch.cuda.is_available()
+    return _bitsandbytes_available  # and torch.cuda.is_available()


 def is_flash_attn_2_available():
```